### PR TITLE
Support response type disambiguation in handler registry

### DIFF
--- a/src/Space.Abstraction/Registry/HandlerRegistry.cs
+++ b/src/Space.Abstraction/Registry/HandlerRegistry.cs
@@ -9,10 +9,10 @@ namespace Space.Abstraction.Registry;
 
 public sealed class HandlerRegistry(IServiceProvider serviceProvider)
 {
-    private Dictionary<(Type, string), object> handlerMap = [];
-    private Dictionary<Type, object> handlerMapByType = [];
-    private ReadOnlyDictionary<(Type, string), object> readOnlyHandlerMap;
-    private ReadOnlyDictionary<Type, object> readOnlyHandlerMapByType;
+    private Dictionary<(Type, string, Type), object> handlerMap = [];
+    private Dictionary<(Type, Type), object> handlerMapByType = [];
+    private ReadOnlyDictionary<(Type, string, Type), object> readOnlyHandlerMap;
+    private ReadOnlyDictionary<(Type, Type), object> readOnlyHandlerMapByType;
     private bool isSealed = false;
     private ISpace space;
 
@@ -27,11 +27,11 @@ public sealed class HandlerRegistry(IServiceProvider serviceProvider)
         if (isSealed)
             throw new InvalidOperationException("Registration is sealed. No more handlers can be registered.");
 
-        var key = SpaceRegistry.GenerateKey<TRequest>(name);
+        var key = SpaceRegistry.GenerateKey<TRequest, TResponse>(name);
         var entry = new SpaceRegistry.HandlerEntry<TRequest, TResponse>(invoker, lightInvoker, pipelines);
 
         handlerMap[key] = entry;
-        handlerMapByType[typeof(TRequest)] = entry;
+        handlerMapByType[(typeof(TRequest), typeof(TResponse))] = entry;
     }
 
     public void RegisterPipeline<TRequest, TResponse>(string handlerName, PipelineConfig pipelineConfig,
@@ -40,7 +40,7 @@ public sealed class HandlerRegistry(IServiceProvider serviceProvider)
         if (isSealed)
             throw new InvalidOperationException("Registration is sealed. No more pipelines can be registered.");
 
-        var key = SpaceRegistry.GenerateKey<TRequest>(handlerName);
+        var key = SpaceRegistry.GenerateKey<TRequest, TResponse>(handlerName);
 
         if (handlerMap.TryGetValue(key, out var handlerObj) && handlerObj is SpaceRegistry.HandlerEntry<TRequest, TResponse> entry)
         {
@@ -52,8 +52,8 @@ public sealed class HandlerRegistry(IServiceProvider serviceProvider)
     {
         if (!isSealed)
         {
-            readOnlyHandlerMap = new ReadOnlyDictionary<(Type, string), object>(handlerMap);
-            readOnlyHandlerMapByType = new ReadOnlyDictionary<Type, object>(handlerMapByType);
+            readOnlyHandlerMap = new ReadOnlyDictionary<(Type, string, Type), object>(handlerMap);
+            readOnlyHandlerMapByType = new ReadOnlyDictionary<(Type, Type), object>(handlerMapByType);
             isSealed = true;
 
             handlerMap = null;
@@ -65,24 +65,24 @@ public sealed class HandlerRegistry(IServiceProvider serviceProvider)
     {
         entry = null;
         if (!isSealed) return false;
-        var key = SpaceRegistry.GenerateKey<TRequest>(name);
+        var key = SpaceRegistry.GenerateKey<TRequest, TResponse>(name);
         if (readOnlyHandlerMap != null && readOnlyHandlerMap.TryGetValue(key, out var obj) && obj is SpaceRegistry.HandlerEntry<TRequest, TResponse> he)
         { entry = he; return true; }
-        if (string.IsNullOrEmpty(name) && readOnlyHandlerMapByType != null && readOnlyHandlerMapByType.TryGetValue(typeof(TRequest), out var byType) && byType is SpaceRegistry.HandlerEntry<TRequest, TResponse> he2)
+        if (string.IsNullOrEmpty(name) && readOnlyHandlerMapByType != null && readOnlyHandlerMapByType.TryGetValue((typeof(TRequest), typeof(TResponse)), out var byType) && byType is SpaceRegistry.HandlerEntry<TRequest, TResponse> he2)
         { entry = he2; return true; }
         return false;
     }
 
-    internal bool TryGetHandlerEntryByRuntimeType(Type requestType, string name, out object entryObj)
+    internal bool TryGetHandlerEntryByRuntimeType(Type requestType, Type responseType, string name, out object entryObj)
     {
         entryObj = null;
         if (!isSealed) return false;
         if (string.IsNullOrEmpty(name))
         {
-            if (readOnlyHandlerMapByType != null && readOnlyHandlerMapByType.TryGetValue(requestType, out var direct))
+            if (readOnlyHandlerMapByType != null && readOnlyHandlerMapByType.TryGetValue((requestType, responseType), out var direct))
             { entryObj = direct; return true; }
         }
-        else if (readOnlyHandlerMap != null && readOnlyHandlerMap.TryGetValue((requestType, name), out var named))
+        else if (readOnlyHandlerMap != null && readOnlyHandlerMap.TryGetValue((requestType, name, responseType), out var named))
         { entryObj = named; return true; }
         return false;
     }
@@ -92,7 +92,7 @@ public sealed class HandlerRegistry(IServiceProvider serviceProvider)
         if (!isSealed)
             throw new InvalidOperationException("Registration is not sealed. Call CompleteRegistration() before dispatching.");
 
-        var key = SpaceRegistry.GenerateKey<TRequest>(name);
+        var key = SpaceRegistry.GenerateKey<TRequest, TResponse>(name);
 
         space ??= execProvider.GetService<ISpace>();
         Space ??= space;
@@ -102,19 +102,22 @@ public sealed class HandlerRegistry(IServiceProvider serviceProvider)
             return entry.Invoke(ctx);
         }
 
-        if (readOnlyHandlerMapByType.TryGetValue(typeof(TRequest), out var typeHandlerObj) && typeHandlerObj is SpaceRegistry.HandlerEntry<TRequest, TResponse> typeEntry)
+        if (readOnlyHandlerMapByType.TryGetValue((typeof(TRequest), typeof(TResponse)), out var typeHandlerObj) && typeHandlerObj is SpaceRegistry.HandlerEntry<TRequest, TResponse> typeEntry)
         {
             return typeEntry.Invoke(ctx);
         }
 
-        throw new InvalidOperationException($"Handler not found for type {typeof(TRequest)} and name '{name}'");
+        throw new InvalidOperationException($"Handler not found for type {typeof(TRequest)} -> {typeof(TResponse)} and name '{name}'");
     }
 
     public ValueTask<object> DispatchHandler(object request, string name = "", CancellationToken ct = default)
-        => DispatchHandlerInternal(request, name, serviceProvider, ct);
+        => DispatchHandlerInternal(request, name, null, serviceProvider, ct);
 
     public ValueTask<object> DispatchHandler(object request, string name, IServiceProvider executionProvider, CancellationToken ct = default)
-        => DispatchHandlerInternal(request, name, executionProvider ?? serviceProvider, ct);
+        => DispatchHandlerInternal(request, name, null, executionProvider ?? serviceProvider, ct);
+
+    public ValueTask<object> DispatchHandler(object request, string name, Type responseType, IServiceProvider executionProvider, CancellationToken ct = default)
+        => DispatchHandlerInternal(request, name, responseType, executionProvider ?? serviceProvider, ct);
 
     public ValueTask<TResponse> DispatchHandler<TRequest, TResponse>(object request, string name, IServiceProvider executionProvider, CancellationToken ct = default)
     {
@@ -124,7 +127,7 @@ public sealed class HandlerRegistry(IServiceProvider serviceProvider)
         return DispatchHandler<TRequest, TResponse>(executionProvider, ctx, name);
     }
 
-    private ValueTask<object> DispatchHandlerInternal(object request, string name, IServiceProvider execProvider, CancellationToken ct)
+    private ValueTask<object> DispatchHandlerInternal(object request, string name, Type responseType, IServiceProvider execProvider, CancellationToken ct)
     {
         if (!isSealed)
             throw new InvalidOperationException("Registration is not sealed. Call CompleteRegistration() before dispatching.");
@@ -136,18 +139,63 @@ public sealed class HandlerRegistry(IServiceProvider serviceProvider)
 
         if (string.IsNullOrEmpty(name))
         {
-            if (readOnlyHandlerMapByType.TryGetValue(type, out var handlerObj) && handlerObj is SpaceRegistry.IObjectHandlerEntry objectHandler)
+            // Prefer disambiguated lookup when responseType provided
+            if (responseType != null)
+            {
+                if (readOnlyHandlerMapByType.TryGetValue((type, responseType), out var handlerObjRt) && handlerObjRt is SpaceRegistry.IObjectHandlerEntry objectHandlerRt)
+                {
+                    var ctx = HandlerContextStruct.Create(execProvider, request, space, ct);
+                    return objectHandlerRt.InvokeObject(ctx);
+                }
+                throw new InvalidOperationException($"Handler not found for type {type} -> {responseType}");
+            }
+            else if (readOnlyHandlerMapByType.TryGetValue((type, typeof(object)), out var objHandler) && objHandler is SpaceRegistry.IObjectHandlerEntry objectHandler)
             {
                 var ctx = HandlerContextStruct.Create(execProvider, request, space, ct);
                 return objectHandler.InvokeObject(ctx);
             }
-            throw new InvalidOperationException($"Handler not found for type {type}");
+            else
+            {
+                // Fallback: try to find a single entry for the request type when response type is unknown
+                if (readOnlyHandlerMapByType != null)
+                {
+                    // enumerate to detect single candidate
+                    int found = 0; SpaceRegistry.IObjectHandlerEntry last = null;
+                    foreach (var kv in readOnlyHandlerMapByType)
+                    {
+                        if (kv.Key.Item1 == type && kv.Value is SpaceRegistry.IObjectHandlerEntry entry)
+                        { found++; last = entry; if (found > 1) break; }
+                    }
+                    if (found == 1)
+                    {
+                        var ctx = HandlerContextStruct.Create(execProvider, request, space, ct);
+                        return last.InvokeObject(ctx);
+                    }
+                }
+                throw new InvalidOperationException($"Handler not found for type {type}");
+            }
         }
 
-        if (readOnlyHandlerMap.TryGetValue((type, name), out var handlerObj2) && handlerObj2 is SpaceRegistry.IObjectHandlerEntry objectHandler2)
+        if (responseType != null)
         {
-            var ctx = HandlerContextStruct.Create(execProvider, request, space, ct);
-            return objectHandler2.InvokeObject(ctx);
+            if (readOnlyHandlerMap.TryGetValue((type, name, responseType), out var handlerObj2) && handlerObj2 is SpaceRegistry.IObjectHandlerEntry objectHandler2)
+            {
+                var ctx = HandlerContextStruct.Create(execProvider, request, space, ct);
+                return objectHandler2.InvokeObject(ctx);
+            }
+            throw new InvalidOperationException($"Handler not found for type {type} -> {responseType} and name '{name}'");
+        }
+        else
+        {
+            // legacy path (may be ambiguous if multiple responses exist)
+            foreach (var kv in readOnlyHandlerMap)
+            {
+                if (kv.Key.Item1 == type && kv.Key.Item2 == (name ?? string.Empty) && kv.Value is SpaceRegistry.IObjectHandlerEntry oh)
+                {
+                    var ctx = HandlerContextStruct.Create(execProvider, request, space, ct);
+                    return oh.InvokeObject(ctx);
+                }
+            }
         }
 
         throw new InvalidOperationException($"Handler not found for type {type} and name '{name}'");

--- a/src/Space.Abstraction/Registry/SpaceRegistry.cs
+++ b/src/Space.Abstraction/Registry/SpaceRegistry.cs
@@ -68,8 +68,8 @@ public partial class SpaceRegistry
 
     // Expose wrapper for runtime type handler entry lookup to optimize object Send path
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool TryGetHandlerEntryByRuntimeType(Type requestType, string name, out object entryObj)
-        => handlerRegistry.TryGetHandlerEntryByRuntimeType(requestType, name, out entryObj);
+    internal bool TryGetHandlerEntryByRuntimeType(Type requestType, Type responseType, string name, out object entryObj)
+        => handlerRegistry.TryGetHandlerEntryByRuntimeType(requestType, responseType, name, out entryObj);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask<TResponse> DispatchHandler<TRequest, TResponse>(IServiceProvider execProvider, HandlerContext<TRequest> ctx, string name = "")
@@ -86,6 +86,11 @@ public partial class SpaceRegistry
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask<object> DispatchHandler(object request, string name, IServiceProvider execProvider, CancellationToken ct = default)
         => handlerRegistry.DispatchHandler(request, name, execProvider, ct);
+
+    // New overload for object dispatch that includes response type for unique resolution
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ValueTask<object> DispatchHandler(object request, string name, Type responseType, IServiceProvider execProvider, CancellationToken ct = default)
+        => handlerRegistry.DispatchHandler(request, name, responseType, execProvider, ct);
 
     public void RegisterNotification<TRequest>(Func<NotificationContext<TRequest>, ValueTask> handler, string name = "")
         => notificationRegistry.RegisterNotification(handler, name);
@@ -116,6 +121,13 @@ public partial class SpaceRegistry
 
     internal static (Type, string) GenerateKey<TRequest>(string name = null)
         => GenerateKey(typeof(TRequest), name);
+
+    // New overloads including response type for handler uniqueness
+    internal static (Type, string, Type) GenerateKey(Type requestType, string name, Type responseType)
+        => (requestType, name ?? string.Empty, responseType);
+
+    internal static (Type, string, Type) GenerateKey<TRequest, TResponse>(string name = null)
+        => GenerateKey(typeof(TRequest), name, typeof(TResponse));
 
     internal static SpaceRegistry CurrentRegistry; // for fast object dispatch
 }

--- a/src/Space.DependencyInjection/Space.cs
+++ b/src/Space.DependencyInjection/Space.cs
@@ -148,7 +148,7 @@ public class Space(IServiceProvider rootProvider, IServiceScopeFactory scopeFact
         {
             using var scope = scopeFactory.CreateScope();
             if (token.IsCancellationRequested) return await ValueTask.FromCanceled<TRes>(token);
-            var result = await spaceRegistry.DispatchHandler(req, handlerName, scope.ServiceProvider, token);
+            var result = await spaceRegistry.DispatchHandler(req, handlerName, typeof(TRes), scope.ServiceProvider, token);
             return (TRes)result!;
         }
     }
@@ -198,7 +198,7 @@ public class Space(IServiceProvider rootProvider, IServiceScopeFactory scopeFact
         async ValueTask SlowPublishScoped(TRequest req, string handlerName, CancellationToken token)
         {
             using var scope = scopeFactory.CreateScope();
-            if (token.IsCancellationRequested) return; // after scope create – acceptable edge
+            if (token.IsCancellationRequested) return; // after scope create  acceptable edge
             var ctx = NotificationContext<TRequest>.Create(scope.ServiceProvider, req, token);
             var vt = spaceRegistry.DispatchNotification(ctx, handlerName).AwaitAndReturnNotificationInvoke(ctx);
             if (!vt.IsCompletedSuccessfully) await vt;

--- a/tests/Space.Tests/Handle/HandlerKeyCollisionTests.cs
+++ b/tests/Space.Tests/Handle/HandlerKeyCollisionTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.DependencyInjection;
+using Space.Abstraction;
+using Space.Abstraction.Attributes;
+using Space.Abstraction.Context;
+using Space.Abstraction.Contracts;
+using Space.DependencyInjection;
+
+namespace Space.Tests.Handle;
+
+[TestClass]
+public class HandlerKeyCollisionTests
+{
+    public record Req(int Id) : IRequest<ResA>;
+    public record ResA(string Value);
+    public record ResB(string Value);
+
+    // Handler 1: Req -> ResA (no name)
+    public class ResAHandler
+    {
+        [Handle]
+        public ValueTask<ResA> Handle(HandlerContext<Req> ctx)
+            => ValueTask.FromResult(new ResA($"A:{ctx.Request.Id}"));
+    }
+
+    // Handler 2: Req -> ResB (no name)
+    public class ResBHandler
+    {
+        [Handle]
+        public ValueTask<ResB> Handle(HandlerContext<Req> ctx)
+            => ValueTask.FromResult(new ResB($"B:{ctx.Request.Id}"));
+    }
+
+    private static ServiceProvider sp;
+    private static ISpace Space;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext context)
+    {
+        var services = new ServiceCollection();
+        services.AddSpace();
+        sp = services.BuildServiceProvider();
+        Space = sp.GetRequiredService<ISpace>();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        sp?.Dispose();
+    }
+
+    [TestMethod]
+    public async Task Typed_Send_Disambiguates_By_ResponseType()
+    {
+        var a = await Space.Send<Req, ResA>(new Req(1));
+        var b = await Space.Send<Req, ResB>(new Req(2));
+
+        Assert.IsNotNull(a);
+        Assert.IsNotNull(b);
+        Assert.AreEqual("A:1", a.Value);
+        Assert.AreEqual("B:2", b.Value);
+    }
+
+    [TestMethod]
+    public async Task Object_Send_Disambiguates_By_ResponseType()
+    {
+        object req1 = new Req(10);
+        object req2 = new Req(20);
+
+        var a = await Space.Send<ResA>(req1);
+        var b = await Space.Send<ResB>(req2);
+
+        Assert.IsNotNull(a);
+        Assert.IsNotNull(b);
+        Assert.AreEqual("A:10", a.Value);
+        Assert.AreEqual("B:20", b.Value);
+    }
+}


### PR DESCRIPTION
Enhanced `HandlerRegistry` and `SpaceRegistry` to include response types in handler registration and lookup keys, enabling unique resolution of handlers based on request type, response type, and name. Updated dictionaries and methods to use `(Type, string, Type)` and `(Type, Type)` keys for better disambiguation.

Added new overloads for `DispatchHandler` to explicitly specify response types, improving flexibility and robustness. Enhanced error messages to include both request and response types for clearer diagnostics. Introduced fallback logic to handle ambiguous lookups when the response type is unknown.

Updated `Space` class to integrate with the new response-type-aware dispatch methods. Added unit tests in `HandlerKeyCollisionTests` to validate behavior when multiple handlers exist for the same request type but different response types. Refactored code for consistency and backward compatibility.

#11