### PR TITLE
feat: Enhance context pooling with thread-local optimization and incr…

### DIFF
--- a/src/Space.Abstraction/Context/PipelineContextPool.cs
+++ b/src/Space.Abstraction/Context/PipelineContextPool.cs
@@ -6,18 +6,38 @@ namespace Space.Abstraction.Context;
 
 public class PipelineContextPool<TRequest>
 {
+    private const int MaxRetained = 1024; // standardized with HandlerContextPool
     private static readonly DefaultObjectPool<PipelineContext<TRequest>> pool =
-        new(new PipelineContextPooledObjectPolicy<TRequest>());
+        new(new PipelineContextPooledObjectPolicy<TRequest>(), maximumRetained: MaxRetained);
+
+    [ThreadStatic]
+    private static PipelineContext<TRequest> threadSlot; // single-thread fast path
 
     public static PipelineContext<TRequest> Get(TRequest request, IServiceProvider serviceProvider, ISpace space, CancellationToken cancellationToken)
     {
-        var ctx = pool.Get();
+        // Fast thread-local reuse (avoids pool hit & lock-free path inside pool)
+        var ctx = threadSlot;
+        if (ctx != null)
+        {
+            threadSlot = null; // consume
+        }
+        else
+        {
+            ctx = pool.Get();
+        }
         ctx.Initialize(request, serviceProvider, space, cancellationToken);
         return ctx;
     }
 
     public static void Return(PipelineContext<TRequest> ctx)
     {
+        // Try place back into thread slot, otherwise pool
+        if (threadSlot == null)
+        {
+            // Clear per-request state already done in Initialize on next use
+            threadSlot = ctx;
+            return;
+        }
         pool.Return(ctx);
     }
 }
@@ -26,5 +46,5 @@ public class PipelineContextPooledObjectPolicy<TRequest> : PooledObjectPolicy<Pi
 {
     public override PipelineContext<TRequest> Create() => new();
 
-    public override bool Return(PipelineContext<TRequest> obj) => true;
+    public override bool Return(PipelineContext<TRequest> obj) => true; // always keep
 }


### PR DESCRIPTION
Expected Performance Benefits:
- Reduced Allocations: Thread-local reuse eliminates repeated allocations for the same thread
- Lower Lock Contention: Thread-local access avoids internal pool locking
- Better CPU Cache Locality: Same thread reusing same context objects
- Consistent Performance: All context pools now have the same optimization characteristics

Impact:
- `NotificationContextPool`: Now matches `HandlerContextPool` performance characteristics
- `PipelineContextPool`: Significant improvement from no explicit pool size + no thread-local optimization
- Overall: More predictable and higher throughput for context-heavy workloads