### PR TITLE
Refactor CI workflows and document versioning process

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -1,16 +1,16 @@
 name: Dev CI (Preview Publish)
 
 on:
-  push:
-    branches:
-      - dev
+  release:
+    types: [published]
 
 concurrency:
   group: dev-ci
   cancel-in-progress: true
 
 jobs:
-  dev-ci:
+  dev-preview:
+    if: ${{ github.event.release.prerelease == true }}
     runs-on: ubuntu-latest
     env:
       DOTNET_NOLOGO: true
@@ -28,21 +28,37 @@ jobs:
             8.x
             9.x
 
-      - name: Restore
-        run: dotnet restore
-
-      - name: Resolve Preview Version
+      - name: Set Preview Version from Release Tag
         id: version
         shell: bash
         run: |
           set -euo pipefail
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.1.0")
-          BASE=${LAST_TAG#v}
-          IFS='.' read -r MA MI PA <<<"$BASE"
-          NEXT_PATCH=$((PA+1))
-          PREVIEW="${MA}.${MI}.${NEXT_PATCH}-preview.${GITHUB_RUN_NUMBER}+sha.$(git rev-parse --short HEAD)"
-          echo "Resolved preview version: $PREVIEW"
-          echo "VERSION=$PREVIEW" >> $GITHUB_ENV
+          RAW_TAG="${{ github.event.release.tag_name }}"
+          if [[ -z "$RAW_TAG" ]]; then
+            echo "Release tag name is empty" >&2
+            exit 1
+          fi
+          # Normalize possible inputs (e.g., refs/tags/v1.0.0, v1.0.0, 1.0.0)
+          TAG=$(echo -n "$RAW_TAG" | tr -d '[:space:]')
+          TAG=${TAG#refs/tags/}
+          TAG=${TAG#tags/}
+          # Strip a single leading v or V
+          if [[ "$TAG" =~ ^[vV]([0-9].*)$ ]]; then
+            BASE_VERSION="${BASH_REMATCH[1]}"
+          else
+            BASE_VERSION="$TAG"
+          fi
+          # Basic SemVer (allow pre-release/build metadata)
+          if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.+].*)?$ ]]; then
+            echo "Tag '$RAW_TAG' produced invalid base version '$BASE_VERSION'. Expected '1.2.3' or 'v1.2.3'." >&2
+            exit 1
+          fi
+          PREVIEW_VERSION="${BASE_VERSION}-preview"
+          echo "Using preview version: $PREVIEW_VERSION from tag: $RAW_TAG"
+          echo "VERSION=$PREVIEW_VERSION" >> $GITHUB_ENV
+
+      - name: Restore
+        run: dotnet restore
 
       - name: Build (Release)
         run: dotnet build -c Release --no-restore -p:Version=${VERSION}

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -1,9 +1,8 @@
 name: Prod CI (Stable Publish)
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 concurrency:
   group: prod-ci
@@ -11,6 +10,7 @@ concurrency:
 
 jobs:
   prod-ci:
+    if: ${{ github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
     env:
       DOTNET_NOLOGO: true
@@ -28,20 +28,33 @@ jobs:
             8.x
             9.x
 
-      - name: Ensure Tag @ HEAD
-        id: tag
+      - name: Set Release Version
+        id: version
         shell: bash
         run: |
           set -euo pipefail
-          if git describe --tags --exact-match >/dev/null 2>&1; then
-            TAG=$(git describe --tags --exact-match)
-            echo "Found tag: $TAG"
-            VERSION=${TAG#v}
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
-          else
-            echo "No exact tag at HEAD. Create a vX.Y.Z tag before pushing to master." >&2
+          RAW_TAG="${{ github.event.release.tag_name }}"
+          if [[ -z "$RAW_TAG" ]]; then
+            echo "Release tag name is empty" >&2
             exit 1
           fi
+          # Normalize possible inputs (e.g., refs/tags/v1.0.0, v1.0.0, 1.0.0)
+          TAG=$(echo -n "$RAW_TAG" | tr -d '[:space:]')
+          TAG=${TAG#refs/tags/}
+          TAG=${TAG#tags/}
+          # Strip a single leading v or V
+          if [[ "$TAG" =~ ^[vV]([0-9].*)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+          else
+            VERSION="$TAG"
+          fi
+          # Basic SemVer (allow pre-release/build metadata)
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.+].*)?$ ]]; then
+            echo "Tag '$RAW_TAG' produced invalid version '$VERSION'. Expected '1.2.3' or 'v1.2.3' (pre-release/build allowed)." >&2
+            exit 1
+          fi
+          echo "Using version: $VERSION from tag: $RAW_TAG"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Restore
         run: dotnet restore

--- a/docs/ProjectDoc.en.md
+++ b/docs/ProjectDoc.en.md
@@ -168,5 +168,29 @@ Module attributes do not define their own methods; they annotate existing `[Hand
 ## 12. Summary
 Space provides a lean, attribute & source-generator driven approach to mediator patterns with extensible, modular cross-cutting pipelines and zero runtime reflection registration cost.
 
+## 13. Versioning & Releases
+This repository uses GitHub Releases to drive NuGet publishing. No packages are published on branch pushes.
+
+- Stable release (prod publish):
+  - Create a GitHub Release and DO NOT mark it as "pre-release".
+  - Tag format: either `vX.Y.Z` or `X.Y.Z` (a single leading `v` is ignored).
+  - The Prod workflow builds, tests, packs, and publishes packages with version `X.Y.Z`.
+
+- Preview release (dev publish):
+  - Create a GitHub Release and mark it as "pre-release".
+  - Tag format: `vX.Y.Z` or `X.Y.Z`.
+  - The Dev workflow builds, tests, packs, and publishes packages with version `X.Y.Z-preview`.
+
+- Validation CI:
+  - Feature branches (`feature/*`, `features/*`) run build/test validation on push.
+  - Pull requests into `dev` or `master` run validation as well.
+
+- Version parsing details:
+  - A single leading `v`/`V` is trimmed (e.g., `v1.2.3` -> `1.2.3`).
+  - Basic SemVer validation is performed. Pre-release/build metadata are supported.
+
+- Local development:
+  - Debug builds use a local version like `0.0.0-local` to avoid colliding with published packages.
+
 ## License
 MIT

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -1,0 +1,55 @@
+# Versioning and Release Publishing
+
+This repository uses GitHub Releases to drive NuGet publishing. Packages are NOT published on branch pushes.
+
+- Stable releases (production publish):
+  - Create a GitHub Release and do not mark it as pre-release.
+  - Tag name can be either vX.Y.Z or X.Y.Z (a single leading v/V is ignored).
+  - The stable workflow builds, tests, packs, and publishes packages with version X.Y.Z.
+
+- Preview releases (dev publish):
+  - Create a GitHub Release and mark it as pre-release.
+  - Tag name can be either vX.Y.Z or X.Y.Z.
+  - The preview workflow builds, tests, packs, and publishes packages with version X.Y.Z-preview.
+
+What runs where
+- Stable publish: .github/workflows/prod-ci.yml
+- Preview publish: .github/workflows/dev-ci.yml (only runs when the release is prerelease=true)
+- Validation builds (no publish): .github/workflows/validation-build.yml
+  - Triggered on pushes to feature/* or features/*, and on pull requests into dev or master.
+
+Tag parsing details
+- The workflows normalize the tag name by:
+  - Trimming whitespace.
+  - Removing refs/tags/ and tags/ prefixes when present.
+  - Stripping a single leading v or V (e.g., v1.2.3 -> 1.2.3).
+- Basic SemVer validation is applied: X.Y.Z with optional pre-release/build metadata.
+
+Projects built and published
+- Space.Abstraction
+- Space.DependencyInjection
+
+The workflows perform these steps
+- dotnet restore
+- dotnet build -c Release (injecting the parsed version)
+- dotnet test (Release)
+- dotnet pack (Release) into artifacts with the parsed version
+- dotnet nuget push artifacts/*.nupkg to nuget.org with skip-duplicate
+
+Secrets required
+- NUGET_API_KEY must be configured in the repository secrets for publishing to NuGet.
+
+Local development notes
+- Debug builds use a safe local version such as 0.0.0-local to avoid clashing with published packages (see csproj files).
+- Release builds in CI set GeneratePackageOnBuild and inject the correct version from the tag.
+
+Examples
+- Stable: tag v1.2.0 (or 1.2.0) -> publish 1.2.0 to NuGet.
+- Preview: tag v1.3.0 (or 1.3.0) and mark the release as pre-release -> publish 1.3.0-preview to NuGet.
+
+Steps to publish
+1) Create a GitHub tag: vX.Y.Z (recommended) or X.Y.Z.
+2) Create a GitHub Release from the tag.
+   - Leave pre-release unchecked for stable.
+   - Check pre-release for preview.
+3) Wait for the corresponding workflow to complete.


### PR DESCRIPTION
Updated `dev-ci.yml` to trigger on GitHub Releases marked as "pre-release" and parse the release tag for versioning. Removed legacy logic for generating preview versions.

Updated `prod-ci.yml` to trigger on GitHub Releases not marked as "pre-release" and parse the release tag for versioning. Replaced old tag validation logic with direct tag parsing.

Added a "Versioning & Releases" section to `ProjectDoc.en.md` to explain the release process, including stable and preview workflows, tag normalization, and local development practices.

Added `Versioning.md` to document the versioning strategy, release workflows, required secrets, and publishing steps in detail. Provided examples for stable and preview releases.