### PR TITLE
Refactor `ParallelNotificationDispatcher` to use `ConfigureAwait(false)`

### DIFF
--- a/src/Space.Abstraction/Registry/Dispatchers/ParallelNotificationDispatcher.cs
+++ b/src/Space.Abstraction/Registry/Dispatchers/ParallelNotificationDispatcher.cs
@@ -10,6 +10,6 @@ public sealed class ParallelNotificationDispatcher : INotificationDispatcher
     public async ValueTask DispatchAsync<TRequest>(IEnumerable<Func<NotificationContext<TRequest>, ValueTask>> handlers, NotificationContext<TRequest> ctx)
     {
         var tasks = handlers.Select(handler => handler(ctx).AsTask());
-        await Task.WhenAll(tasks);
+        await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
**File**: `src/Space.Abstraction/Registry/Dispatchers/ParallelNotificationDispatcher.cs`:13

**Issue:** Missing `ConfigureAwait(false)` in **library code**

**Fix:** Add `.ConfigureAwait(false)` to all `await` calls in **library code**

**Impact:** Prevents potential deadlocks in synchronous calling contexts