### PR TITLE
docs: clarify root aggregator dual package requirement

### DIFF
--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -1,5 +1,10 @@
 # Known Issues / Breaking Changes
 
+- Breaking (Packaging shift): The Space.SourceGenerator analyzer now ships with `Space.Abstraction`. `Space.DependencyInjection` only contains DI extensions and runtime implementations.
+  - Migration: Add `Space.Abstraction` to EVERY project that uses Space attributes. For host/root projects that use DI, also reference `Space.DependencyInjection`. Remove any direct `Space.SourceGenerator` references.
+  - Root aggregator project MUST reference BOTH packages. Satellite libraries typically only need `Space.Abstraction`.
+  - Benefit: Compile-time generation works even without DI; DI is optional for libraries.
+
 - Breaking (Multi-Project Root Aggregator): A new MSBuild property `<SpaceGenerateRootAggregator>` controls which project generates the root dependency injection aggregator (`DependencyInjectionExtensions.g.cs`). Other projects now generate lightweight `SpaceAssemblyRegistration_<Assembly>.g.cs` files. You MUST set this property to `true` in exactly one root project when using multiple handler class libraries. See `MultiProjectSetup.md`.
   - Migration: Add `<SpaceGenerateRootAggregator>true</SpaceGenerateRootAggregator>` to your host / composition root `.csproj`. Set `false` (or omit) in feature libraries.
   - Benefit: Enables discovery & registration of handlers/pipelines/modules/notifications across multiple assemblies without duplicate roots or manual DI wiring.
@@ -8,9 +13,9 @@
   - Migration:
     - If your request already implements `IRequest<TRes>`, nothing to change.
     - If not, either add `IRequest<TRes>` to your request type, or use `Send<TRes>(IRequest<TRes> request)` or `Send<TRes>(object request)` overloads.
-  - Benefit: compile-time safety and better discoverability.
+  - Benefit: Better compile-time safety and discoverability.
 
-- Circular dependency in `ISpace` and `SpaceRegistry`: The first handler receives a null `ISpace(Lazy)` instance, which is set on subsequent requests.
+- Circular dependency in `ISpace` and `SpaceRegistry`: The first handler may observe a null `ISpace` (lazy) instance; it is populated on subsequent requests.
 - ~~When using handler names, modules are applied to all handlers instead of only those with the attribute.~~ (Fixed)
 
 Refer also to `MultiProjectSetup.md` for architectural details.

--- a/src/Space.DependencyInjection/README.md
+++ b/src/Space.DependencyInjection/README.md
@@ -1,12 +1,22 @@
 # Space.DependencyInjection
 
-Dependency Injection extensions + source generator bootstrap for the Space framework. Provides the `AddSpace` entry point that wires up all discovered handlers, pipelines, notifications and system modules without runtime reflection.
+Dependency Injection extensions and runtime implementations for the Space framework. Provides the `AddSpace` entry point that wires up all discovered handlers, pipelines, notifications and system modules without runtime reflection.
 
 ## Install
 ```bash
- dotnet add package Space.DependencyInjection
+ dotnet add package Space.Abstraction            # brings attributes + source generator analyzer
+ dotnet add package Space.DependencyInjection    # brings DI extensions + ISpace implementation
 ```
-(Brings in `Space.Abstraction`.)
+
+## Root Aggregator (Multi-Project)
+- Mark exactly one project as root aggregator:
+```xml
+<PropertyGroup>
+  <SpaceGenerateRootAggregator>true</SpaceGenerateRootAggregator>
+</PropertyGroup>
+```
+- That root project MUST reference BOTH `Space.Abstraction` and `Space.DependencyInjection`.
+- Satellite libraries that only contain handlers/pipelines/notifications should reference `Space.Abstraction` to bring the analyzer (DI package is optional for them).
 
 ## Quick Start
 ```csharp
@@ -16,7 +26,7 @@ services.AddSpace(options =>
     options.ServiceLifetime = ServiceLifetime.Scoped;      // Lifetime of generated registrations
     options.NotificationDispatchType = NotificationDispatchType.Parallel; // or Sequential
 });
-// Optional built?in module providers
+// Optional built–in module providers
 services.AddSpaceInMemoryCache(); // if using InMemoryCache module package
 
 var provider = services.BuildServiceProvider();
@@ -24,36 +34,10 @@ var space = provider.GetRequiredService<ISpace>();
 
 // Send a request
 var loginResponse = await space.Send<UserLoginResponse>(new UserLoginRequest("demo"));
-
-// Publish an event (all [Notification] handlers of matching event type will be invoked)
-await space.Publish(new UserLoggedInSuccessfully("demo"));
-```
-
-## Named Handlers
-If multiple `[Handle]` methods target the same request/response, give them distinct `Name` values and select at call time:
-```csharp
-var result = await space.Send<PriceResult>(query /* request object */, handlerName: "Discounted");
-```
-(The overload with `handlerName` is source?generated.)
-
-## Modules
-Framework & custom modules are activated by annotating handler methods with their module attribute (e.g. `[CacheModule(Duration = 60)]`). System modules run before user pipelines. Add supporting package/providers before calling the handler.
-
-### In-Memory Cache Example
-```csharp
-services.AddSpace();
-services.AddSpaceInMemoryCache();
-
-public class UserQueries
-{
-    [Handle]
-    [CacheModule(Duration = 30)]
-    public ValueTask<UserDetail> GetUser(HandlerContext<UserId> ctx) => ...;
-}
 ```
 
 ## Source-Generated Extensions (Internal)
-The generator emits and `AddSpace` invokes:
+The generator (included via Space.Abstraction) emits and `AddSpace` invokes:
 - `AddSpaceSourceGenerated(IServiceCollection, Action<SpaceOptions>?)`
 - `AddSpaceModules(IServiceCollection)`
 You normally just call `services.AddSpace(...)`.
@@ -62,7 +46,7 @@ You normally just call `services.AddSpace(...)`.
 Configure dispatch strategy via `SpaceOptions.NotificationDispatchType` (Parallel or Sequential). Each `[Notification]` method receives a `NotificationContext<TEvent>`.
 
 ## Pipelines
-Add cross?cutting logic with `[Pipeline]` methods using `PipelineContext<TRequest>`; use `Order` to influence execution relative to other pipelines (modules use very low values to run first).
+Add cross–cutting logic with `[Pipeline]` methods using `PipelineContext<TRequest>`; use `Order` to influence execution relative to other pipelines (modules use very low values to run first).
 
 ## Performance
 No runtime reflection: all registrations & handler metadata are generated at build time for minimal overhead.


### PR DESCRIPTION
Clarify packaging shift and multi-project usage:

- Explicitly document that the root aggregator project must reference BOTH Space.Abstraction (analyzer) and Space.DependencyInjection (runtime DI)
- Satellite libraries only need Space.Abstraction
- English-only docs enforcement

Updated files:
- docs/ProjectDoc.en.md
- docs/KnownIssues.md
- src/Space.DependencyInjection/README.md

Also added local sample csproj notes (ApiHost, LibAlpha) previously.

Please review for accuracy and wording before merge into dev.