### PR TITLE
Refactor packaging and improve multi-project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,39 @@ High-performance, source-generator powered mediator / messaging framework for .N
 
 | Package | Stable | Preview | Downloads | Description |
 |---------|--------|---------|-----------|-------------|
-| Space.Abstraction | ![NuGet](https://img.shields.io/nuget/v/Space.Abstraction.svg) | ![NuGet (pre)](https://img.shields.io/nuget/vpre/Space.Abstraction.svg) | ![Downloads](https://img.shields.io/nuget/dt/Space.Abstraction.svg) | Core abstractions: attributes, contexts, contracts |
-| Space.DependencyInjection | ![NuGet](https://img.shields.io/nuget/v/Space.DependencyInjection.svg) | ![NuGet (pre)](https://img.shields.io/nuget/vpre/Space.DependencyInjection.svg) | ![Downloads](https://img.shields.io/nuget/dt/Space.DependencyInjection.svg) | DI extensions + source generator bootstrap |
+| Space.Abstraction | ![NuGet](https://img.shields.io/nuget/v/Space.Abstraction.svg) | ![NuGet (pre)](https://img.shields.io/nuget/vpre/Space.Abstraction.svg) | ![Downloads](https://img.shields.io/nuget/dt/Space.Abstraction.svg) | Core abstractions + Source Generator analyzer (attributes, contexts, contracts) |
+| Space.DependencyInjection | ![NuGet](https://img.shields.io/nuget/v/Space.DependencyInjection.svg) | ![NuGet (pre)](https://img.shields.io/nuget/vpre/Space.DependencyInjection.svg) | ![Downloads](https://img.shields.io/nuget/dt/Space.DependencyInjection.svg) | DI extensions & runtime implementations (ISpace) |
 | [Space.Modules.InMemoryCache](https://github.com/salihcantekin/Space.Modules.InMemoryCache) | ![NuGet](https://img.shields.io/nuget/v/Space.Modules.InMemoryCache.svg) | ![NuGet (pre)](https://img.shields.io/nuget/vpre/Space.Modules.InMemoryCache.svg) | ![Downloads](https://img.shields.io/nuget/dt/Space.Modules.InMemoryCache.svg) | In-memory caching module + attribute integration |
 
-### Install (Minimal)
+### Breaking Change (Packaging)
+Old behavior: `Space.DependencyInjection` implicitly brought abstractions + source generator.
+New behavior: Source generator analyzer ships with `Space.Abstraction`. You must reference BOTH packages for full DI usage.
+
+Migration:
+1. Add `Space.Abstraction` to all projects that use Space attributes.
+2. Add `Space.DependencyInjection` only where you need `ISpace` and registration extensions.
+3. Remove any direct `Space.SourceGenerator` references; they are now unnecessary.
+
+### Install (Minimal DI Usage)
 ```bash
-dotnet add package Space.DependencyInjection (brings Space.Abstraction)
+dotnet add package Space.Abstraction
+
+dotnet add package Space.DependencyInjection
 ```
 Optional module:
 ```bash
 dotnet add package Space.Modules.InMemoryCache
 ```
+If you only need compile-time generation (e.g., custom runtime) reference just `Space.Abstraction`.
 
 ---
 ## Quick Start
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
+using Space.Abstraction;
+using Space.Abstraction.Attributes;
+using Space.Abstraction.Context;
+using Space.Abstraction.Contracts;
 
 var services = new ServiceCollection();
 services.AddSpace(opt =>
@@ -44,11 +60,7 @@ services.AddSpaceInMemoryCache(); // if caching module needed
 var provider = services.BuildServiceProvider();
 var space = provider.GetRequiredService<ISpace>();
 
-public sealed record UserLoginRequest(string UserName);
-/*
-The response type can be defined using IRequest<T>.
-*/
-public sealed record UserLoginRequest(string UserName) : IRequest<UserLoginResponse>
+public sealed record UserLoginRequest(string UserName) : IRequest<UserLoginResponse>;
 public sealed record UserLoginResponse(bool Success);
 
 public class UserHandlers
@@ -58,22 +70,15 @@ public class UserHandlers
         => ValueTask.FromResult(new UserLoginResponse(true));
 }
 
- /*
- The same functionality can be implemented using the IHandler<UserLoginRequest,  UserLoginResponse> interface.
- The primary difference from the attribute-based approach is that the method name will be explicitly defined in the interface implementation.
-*/
-
-public class UserHandlers : IHandler<UserLoginRequest, UserLoginResponse>
+// Interface-based alternative
+public class UserHandlersInterface : IHandler<UserLoginRequest, UserLoginResponse>
 {
-    public ValueTask<UserLoginResponse> Handle  (UserLoginRequest request, CancellationToken  cancellationToken)
-        => ValueTask.FromResult(new UserLoginResponse   (true));
+    public ValueTask<UserLoginResponse> Handle(UserLoginRequest request, CancellationToken cancellationToken)
+        => ValueTask.FromResult(new UserLoginResponse(true));
 }
 
-var response = await space.Send<UserLoginResponse>(new UserLoginRequest("demo"));
-/*
-A more efficient solution can be achieved in the Send method by utilizing both the request and response types.
-*/
-var response = await space.Send<UserLoginRequest, UserLoginResponse>(new UserLoginRequest("demo"))
+var response1 = await space.Send<UserLoginResponse>(new UserLoginRequest("demo"));
+var response2 = await space.Send<UserLoginRequest, UserLoginResponse>(new UserLoginRequest("demo"));
 ```
 
 ### Named Handlers
@@ -83,7 +88,7 @@ public class PricingHandlers
     [Handle(Name = "Default")] public ValueTask<PriceResult> GetDefault(HandlerContext<PriceQuery> ctx) => ...;
     [Handle(Name = "Discounted")] public ValueTask<PriceResult> GetDiscounted(HandlerContext<PriceQuery> ctx) => ...;
 }
-var discounted = await space.Send<PriceResult>(new PriceQuery(...), handlerName: "Discounted");
+var discounted = await space.Send<PriceResult>(new PriceQuery(...), name: "Discounted");
 ```
 
 ### Pipelines
@@ -91,11 +96,9 @@ var discounted = await space.Send<PriceResult>(new PriceQuery(...), handlerName:
 public class LoggingPipeline
 {
     [Pipeline(Order = 100)]
-    public async ValueTask<TResponse> Log<TRequest, TResponse>(PipelineContext<TRequest> ctx)
+    public async ValueTask<UserLoginResponse> Log(PipelineContext<UserLoginRequest> ctx, PipelineDelegate<UserLoginRequest, UserLoginResponse> next)
     {
-        // pre-execution 
-        var result = await ctx.Next(ctx);
-        // post-execution
+        var result = await next(ctx);
         return result;
     }
 }
@@ -117,7 +120,7 @@ await space.Publish(new UserLoggedIn("demo"));
 public class UserQueries
 {
     [Handle]
-    [CacheModule(DurationSeconds = 60)]
+    [CacheModule(Duration = 60)]
     public ValueTask<UserProfile?> GetUser(HandlerContext<UserId> ctx) => ...;
 }
 ```
@@ -132,6 +135,7 @@ public class UserQueries
 - Extensible module model (e.g., cache) before user pipelines
 - High-performance async signatures (`ValueTask`)
 - Parallel or sequential notification dispatch
+- Multi-project root aggregator property `<SpaceGenerateRootAggregator>`
 - Multi-targeting (netstandard2.0 + modern .NET)
 
 ---
@@ -141,7 +145,7 @@ Space front-loads cost at build time to reduce runtime overhead:
 - No reflection-based runtime scanning
 - Low allocation pathways (current & planned pooling)
 
-Benchmarks (planned) will compare against other mediator libraries.
+Benchmarks compare against other mediator libraries in `tests/Space.Benchmarks`.
 
 ---
 ## Documentation
@@ -166,14 +170,14 @@ Per-package:
 ## Roadmap & Issues
 See GitHub Issues for:
 - Planned improvements (attribute parameters, global defaults, Options pattern)
-- Known issues (initial Lazy `ISpace` null, module scoping on named handlers)
+- Known issues (initial Lazy `ISpace` null, module scoping bugs)
 
 Contributions welcome via issues & PRs.
 
 ---
 ## Versioning & Releases
 - `master`: tagged semantic versions (`vX.Y.Z`) ? stable NuGet
-- `dev`: continuous preview (`X.Y.(Patch+1)-preview.<run>`)
+- `dev`: preview releases (`X.Y.Z-preview`)
 - Feature branches: validation build only
 
 ---
@@ -185,7 +189,7 @@ MIT.
 APIs may evolve while early preview features stabilize. Track releases for changes.
 
 ---
-# Space
+# Space (Short)
 
 Space is a high-performance, source-generator powered mediator/messaging framework for .NET.
 

--- a/docs/DeveloperRecommendations.md
+++ b/docs/DeveloperRecommendations.md
@@ -1,5 +1,6 @@
 # Developer Recommendations
 
+- Always reference both `Space.Abstraction` (brings analyzer) and `Space.DependencyInjection` (runtime DI) unless you only need compile-time generation without provided DI.
 - Use `Notification.Publish` with configurable `DispatchType` for flexible event handling.
 - Integrate with `LoggerFactory` for advanced logging.
 - Follow interface and config standards when implementing custom modules.
@@ -13,4 +14,4 @@
 - Benchmarks: run `tests/Space.Benchmarks` to compare typed/IRequest/object Send paths.
 - Always run `dotnet format` before committing.
 
-For more, see [ProjectDoc.txt](ProjectDoc.txt).
+For more, see [ProjectDoc.en.md](ProjectDoc.en.md) and [KnownIssues.md](KnownIssues.md).

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -1,5 +1,10 @@
 # Known Issues / Breaking Changes
 
+- Breaking (Packaging shift): The Space.SourceGenerator analyzer now ships with `Space.Abstraction`. `Space.DependencyInjection` only contains DI extensions and runtime implementations.
+  - Migration: Add `Space.Abstraction` to EVERY project that uses Space attributes. For host/root projects that use DI, also reference `Space.DependencyInjection`. Remove any direct `Space.SourceGenerator` references.
+  - Root aggregator project MUST reference BOTH packages. Satellite libraries typically only need `Space.Abstraction`.
+  - Benefit: Compile-time generation works even without DI; DI is optional for libraries.
+
 - Breaking (Multi-Project Root Aggregator): A new MSBuild property `<SpaceGenerateRootAggregator>` controls which project generates the root dependency injection aggregator (`DependencyInjectionExtensions.g.cs`). Other projects now generate lightweight `SpaceAssemblyRegistration_<Assembly>.g.cs` files. You MUST set this property to `true` in exactly one root project when using multiple handler class libraries. See `MultiProjectSetup.md`.
   - Migration: Add `<SpaceGenerateRootAggregator>true</SpaceGenerateRootAggregator>` to your host / composition root `.csproj`. Set `false` (or omit) in feature libraries.
   - Benefit: Enables discovery & registration of handlers/pipelines/modules/notifications across multiple assemblies without duplicate roots or manual DI wiring.
@@ -8,9 +13,9 @@
   - Migration:
     - If your request already implements `IRequest<TRes>`, nothing to change.
     - If not, either add `IRequest<TRes>` to your request type, or use `Send<TRes>(IRequest<TRes> request)` or `Send<TRes>(object request)` overloads.
-  - Benefit: compile-time safety and better discoverability.
+  - Benefit: Better compile-time safety and discoverability.
 
-- Circular dependency in `ISpace` and `SpaceRegistry`: The first handler receives a null `ISpace(Lazy)` instance, which is set on subsequent requests.
+- Circular dependency in `ISpace` and `SpaceRegistry`: The first handler may observe a null `ISpace` (lazy) instance; it is populated on subsequent requests.
 - ~~When using handler names, modules are applied to all handlers instead of only those with the attribute.~~ (Fixed)
 
 Refer also to `MultiProjectSetup.md` for architectural details.

--- a/docs/ProjectDoc.txt
+++ b/docs/ProjectDoc.txt
@@ -11,8 +11,9 @@ Key motivations:
 - Support named handlers so multiple strategies can coexist for a single request/response pair.
 
 ## Required NuGet Packages
-Minimal usage:
-- Space.DependencyInjection (brings Space.Abstraction)
+Minimal usage now requires referencing both:
+- Space.Abstraction (brings the Space.SourceGenerator analyzer automatically)
+- Space.DependencyInjection (DI extensions and runtime implementations)
 
 Optional modules:
 - Space.Modules.InMemoryCache (caching)
@@ -132,6 +133,8 @@ Space focuses on build-time computation (source generation) to deliver a lean, l
 - No runtime reflection for discovery
 
 For full, updated documentation prefer the Markdown files under `docs/` (e.g., `ProjectDoc.en.md`). This legacy plain text file is retained for compatibility.
+
+
 
 
 

--- a/src/Space.Abstraction/Space.Abstraction.csproj
+++ b/src/Space.Abstraction/Space.Abstraction.csproj
@@ -2,29 +2,31 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<RootNamespace>Space.Abstraction</RootNamespace>
 		<LangVersion>latest</LangVersion>
 		<!-- NuGet package metadata -->
 		<PackageId>Space.Abstraction</PackageId>
 		<Authors>salihcantekin</Authors>
 		<Company>Space</Company>
-		<Description>Abstractions for the Space framework, including core interfaces, attributes, and modular pipeline contracts for high-performance .NET applications.</Description>
-		<PackageTags>abstraction;space;mediator;pipeline;modular;dotnet</PackageTags>
+		<Description>Core abstractions (interfaces, attributes, contracts) for the Space framework. Automatically includes the Space.SourceGenerator analyzer for compile-time registration.</Description>
+		<PackageTags>abstraction;space;mediator;pipeline;modular;dotnet;analyzer;sourcegenerator</PackageTags>
 		<RepositoryUrl>https://github.com/salihcantekin/Space</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/salihcantekin/Space</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<IncludeBuildOutput>true</IncludeBuildOutput>
 		<PackageIcon>icon.png</PackageIcon>
+		<AssemblyName>Space.Abstraction</AssemblyName>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="icon.png" Pack="true" PackagePath="" />
+		<!-- Pack analyzer dll from built Space.SourceGenerator project -->
+		<None Include="..\Space.SourceGenerator\bin\$(Configuration)\netstandard2.0\Space.SourceGenerator.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" Condition="Exists('..\Space.SourceGenerator\bin\$(Configuration)\netstandard2.0\Space.SourceGenerator.dll')" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
-		<Version>0.0.6-local</Version>
-		<InformationalVersion>0.0.6-local+$(SourceRevisionId)</InformationalVersion>
+		<Version>0.0.8-local</Version>
+		<InformationalVersion>0.0.8-local+$(SourceRevisionId)</InformationalVersion>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 	</PropertyGroup>
 
@@ -33,5 +35,13 @@
 		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.0-preview.7.25380.108" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Space.SourceGenerator\Space.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<Target Name="BuildSourceGeneratorBeforePack" BeforeTargets="Pack">
+		<MSBuild Projects="..\Space.SourceGenerator\Space.SourceGenerator.csproj" Targets="Build" Properties="Configuration=$(Configuration)" />
+	</Target>
 
 </Project>

--- a/src/Space.DependencyInjection/README.md
+++ b/src/Space.DependencyInjection/README.md
@@ -1,12 +1,22 @@
 # Space.DependencyInjection
 
-Dependency Injection extensions + source generator bootstrap for the Space framework. Provides the `AddSpace` entry point that wires up all discovered handlers, pipelines, notifications and system modules without runtime reflection.
+Dependency Injection extensions and runtime implementations for the Space framework. Provides the `AddSpace` entry point that wires up all discovered handlers, pipelines, notifications and system modules without runtime reflection.
 
 ## Install
 ```bash
- dotnet add package Space.DependencyInjection
+ dotnet add package Space.Abstraction            # brings attributes + source generator analyzer
+ dotnet add package Space.DependencyInjection    # brings DI extensions + ISpace implementation
 ```
-(Brings in `Space.Abstraction`.)
+
+## Root Aggregator (Multi-Project)
+- Mark exactly one project as root aggregator:
+```xml
+<PropertyGroup>
+  <SpaceGenerateRootAggregator>true</SpaceGenerateRootAggregator>
+</PropertyGroup>
+```
+- That root project MUST reference BOTH `Space.Abstraction` and `Space.DependencyInjection`.
+- Satellite libraries that only contain handlers/pipelines/notifications should reference `Space.Abstraction` to bring the analyzer (DI package is optional for them).
 
 ## Quick Start
 ```csharp
@@ -16,7 +26,7 @@ services.AddSpace(options =>
     options.ServiceLifetime = ServiceLifetime.Scoped;      // Lifetime of generated registrations
     options.NotificationDispatchType = NotificationDispatchType.Parallel; // or Sequential
 });
-// Optional built?in module providers
+// Optional built–in module providers
 services.AddSpaceInMemoryCache(); // if using InMemoryCache module package
 
 var provider = services.BuildServiceProvider();
@@ -32,9 +42,8 @@ await space.Publish(new UserLoggedInSuccessfully("demo"));
 ## Named Handlers
 If multiple `[Handle]` methods target the same request/response, give them distinct `Name` values and select at call time:
 ```csharp
-var result = await space.Send<PriceResult>(query /* request object */, handlerName: "Discounted");
+var result = await space.Send<PriceResult>(query /* request object */, name: "Discounted");
 ```
-(The overload with `handlerName` is source?generated.)
 
 ## Modules
 Framework & custom modules are activated by annotating handler methods with their module attribute (e.g. `[CacheModule(Duration = 60)]`). System modules run before user pipelines. Add supporting package/providers before calling the handler.
@@ -53,7 +62,7 @@ public class UserQueries
 ```
 
 ## Source-Generated Extensions (Internal)
-The generator emits and `AddSpace` invokes:
+The generator (included via Space.Abstraction) emits and `AddSpace` invokes:
 - `AddSpaceSourceGenerated(IServiceCollection, Action<SpaceOptions>?)`
 - `AddSpaceModules(IServiceCollection)`
 You normally just call `services.AddSpace(...)`.
@@ -62,7 +71,7 @@ You normally just call `services.AddSpace(...)`.
 Configure dispatch strategy via `SpaceOptions.NotificationDispatchType` (Parallel or Sequential). Each `[Notification]` method receives a `NotificationContext<TEvent>`.
 
 ## Pipelines
-Add cross?cutting logic with `[Pipeline]` methods using `PipelineContext<TRequest>`; use `Order` to influence execution relative to other pipelines (modules use very low values to run first).
+Add cross–cutting logic with `[Pipeline]` methods using `PipelineContext<TRequest>`; use `Order` to influence execution relative to other pipelines (modules use very low values to run first).
 
 ## Performance
 No runtime reflection: all registrations & handler metadata are generated at build time for minimal overhead.

--- a/src/Space.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Space.DependencyInjection/ServiceCollectionExtensions.cs
@@ -150,9 +150,9 @@ public static class ServiceCollectionExtensions
 
         object[] callArgs = parameters.Length switch
         {
-            1 => new object[] { services },
-            2 when allowConfigure => new object[] { services, configure },
-            _ => new object[] { services }
+            1 => [services],
+            2 when allowConfigure => [services, configure],
+            _ => [services]
         };
 
         method.Invoke(null, callArgs);
@@ -168,9 +168,15 @@ public static class ServiceCollectionExtensions
                 {
                     var ps = m.GetParameters();
 
-                    if (ps.Length == 0) return false;
-                    if (!typeof(IServiceCollection).IsAssignableFrom(ps[0].ParameterType)) return false;
-                    if (ps.Length == 2 && !allowConfigure) return false;
+                    if (ps.Length == 0) 
+                        return false;
+                    
+                    if (!typeof(IServiceCollection).IsAssignableFrom(ps[0].ParameterType)) 
+                        return false;
+
+                    if (ps.Length == 2 && !allowConfigure) 
+                        return false;
+
                     return true;
                 });
     }
@@ -222,11 +228,14 @@ public static class ServiceCollectionExtensions
 
     private static void PreloadUserAssemblies()
     {
-        if (userAssembliesPreloaded) return;
+        if (userAssembliesPreloaded) 
+            return;
+
         userAssembliesPreloaded = true;
 
         var entry = Assembly.GetEntryAssembly();
-        if (entry == null) return;
+        if (entry == null) 
+            return;
 
         var skipPrefixes = new string[] { "System", "Microsoft", "mscorlib", "netstandard", "Windows" };
 
@@ -236,10 +245,7 @@ public static class ServiceCollectionExtensions
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             var simple = asm.GetName().Name;
-            if (!loaded.ContainsKey(simple))
-            {
-                loaded.Add(simple, asm);
-            }
+            loaded.TryAdd(simple, asm);
         }
 
         var q = new Queue<AssemblyName>(entry.GetReferencedAssemblies());
@@ -248,8 +254,13 @@ public static class ServiceCollectionExtensions
         {
             var an = q.Dequeue();
             var name = an.Name;
-            if (loaded.ContainsKey(name)) continue;
-            if (skipPrefixes.Any(p => name.StartsWith(p, StringComparison.Ordinal))) continue;
+
+            if (loaded.ContainsKey(name)) 
+                continue;
+
+            if (skipPrefixes.Any(p => name.StartsWith(p, StringComparison.Ordinal))) 
+                continue;
+
             try
             {
                 var asm = Assembly.Load(an);
@@ -272,14 +283,29 @@ public static class ServiceCollectionExtensions
     #region Utilities
     private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
     {
-        try { return assembly.GetTypes(); }
-        catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t is not null)!; }
-        catch { return Array.Empty<Type>(); }
+        try 
+        { 
+            return assembly.GetTypes(); 
+        }
+        catch (ReflectionTypeLoadException ex) 
+        { 
+            return ex.Types.Where(t => t is not null)!; 
+        }
+        catch 
+        { 
+            return []; 
+        }
     }
 
     private static void TryLoad(Action load)
     {
-        try { load(); } catch { }
+        try 
+        { 
+            load(); 
+        }
+        catch 
+        {
+        }
     }
     #endregion
 

--- a/src/Space.DependencyInjection/Space.DependencyInjection.csproj
+++ b/src/Space.DependencyInjection/Space.DependencyInjection.csproj
@@ -7,8 +7,8 @@
 		<PackageId>Space.DependencyInjection</PackageId>
 		<Authors>salihcantekin</Authors>
 		<Company>Space</Company>
-		<Description>Dependency Injection extensions for the Space framework. Automatically brings in the Space source generator analyzer for compile-time registration.</Description>
-		<PackageTags>dependencyinjection;space;sourcegenerator;analyzer;dotnet</PackageTags>
+		<Description>Dependency Injection extensions and runtime implementations for the Space framework.</Description>
+		<PackageTags>dependencyinjection;space;dotnet</PackageTags>
 		<RepositoryUrl>https://github.com/salihcantekin/Space</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/salihcantekin/Space</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -22,15 +22,14 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
-		<Version>0.0.7-local</Version>
-		<InformationalVersion>0.0.7-local+$(SourceRevisionId)</InformationalVersion>
+		<Version>0.0.8-local</Version>
+		<InformationalVersion>0.0.8-local+$(SourceRevisionId)</InformationalVersion>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="icon.png" Pack="true" PackagePath="" />
 		<None Include="README.md" Pack="true" PackagePath="" />
-		<None Include="..\Space.SourceGenerator\bin\$(Configuration)\netstandard2.0\Space.SourceGenerator.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" Condition="Exists('..\Space.SourceGenerator\bin\$(Configuration)\netstandard2.0\Space.SourceGenerator.dll')" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -42,9 +41,5 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Space.Abstraction\Space.Abstraction.csproj" />
 	</ItemGroup>
-
-	<Target Name="BuildSourceGeneratorBeforePack" BeforeTargets="Pack">
-		<MSBuild Projects="..\Space.SourceGenerator\Space.SourceGenerator.csproj" Targets="Build" Properties="Configuration=$(Configuration)" />
-	</Target>
 
 </Project>

--- a/tests/MultiProjects/NuGetLoaded/ApiHost/ApiHost.csproj
+++ b/tests/MultiProjects/NuGetLoaded/ApiHost/ApiHost.csproj
@@ -7,7 +7,13 @@
 		<!-- Mark this as root so source generator aggregates satellite libraries -->
 		<SpaceGenerateRootAggregator>true</SpaceGenerateRootAggregator>
 
+		<!--<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>-->
 	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Space.Abstraction" Version="0.0.8-local" />
+		<PackageReference Include="Space.DependencyInjection" Version="0.0.8-local" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="../LibAlpha/LibAlpha.csproj" />

--- a/tests/MultiProjects/NuGetLoaded/ApiHost/ApiHost.csproj
+++ b/tests/MultiProjects/NuGetLoaded/ApiHost/ApiHost.csproj
@@ -11,8 +11,8 @@
 		<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>-->
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Space.Abstraction" Version="0.0.8-local" />
-		<PackageReference Include="Space.DependencyInjection" Version="0.0.8-local" />
+		<PackageReference Include="Space.Abstraction" Version="2.0.0" />
+		<PackageReference Include="Space.DependencyInjection" Version="2.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/MultiProjects/NuGetLoaded/LibAlpha/AlphaHandlers.cs
+++ b/tests/MultiProjects/NuGetLoaded/LibAlpha/AlphaHandlers.cs
@@ -1,5 +1,3 @@
-
-
 using Space.Abstraction.Attributes;
 using Space.Abstraction.Context;
 using Space.Abstraction.Contracts;

--- a/tests/MultiProjects/NuGetLoaded/LibAlpha/LibAlpha.csproj
+++ b/tests/MultiProjects/NuGetLoaded/LibAlpha/LibAlpha.csproj
@@ -7,19 +7,17 @@
 		<!--<UseLocalSpaceProjects Condition="'$(UseLocalSpaceProjects)'==''">true</UseLocalSpaceProjects>-->
 		<UseLocalSpaceProjects>false</UseLocalSpaceProjects>
 		<SpaceGenerateRootAggregator>false</SpaceGenerateRootAggregator>
+
+		<!--<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>-->
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(UseLocalSpaceProjects)'=='true'">
 		<!-- corrected relative paths (go up 4 levels to solution root) -->
 		<ProjectReference Include="../../../../src/Space.Abstraction/Space.Abstraction.csproj" />
-		<ProjectReference Include="../../../../src/Space.DependencyInjection/Space.DependencyInjection.csproj" />
-		<ProjectReference Include="../../../../src/Space.SourceGenerator/Space.SourceGenerator.csproj"
-						  OutputItemType="Analyzer"
-						  ReferenceOutputAssembly="false"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(UseLocalSpaceProjects)'!='true'">
-		<!-- Replace version with the package version you want to test -->
-		<PackageReference Include="Space.DependencyInjection" Version="2.0.0-preview" />
+		<PackageReference Include="Space.Abstraction" Version="0.0.8-local" />
 	</ItemGroup>
 </Project>

--- a/tests/MultiProjects/NuGetLoaded/LibAlpha/LibAlpha.csproj
+++ b/tests/MultiProjects/NuGetLoaded/LibAlpha/LibAlpha.csproj
@@ -18,6 +18,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(UseLocalSpaceProjects)'!='true'">
-		<PackageReference Include="Space.Abstraction" Version="0.0.8-local" />
+		<PackageReference Include="Space.Abstraction" Version="2.0.0" />
 	</ItemGroup>
 </Project>

--- a/tests/MultiProjects/NuGetLoaded/README.md
+++ b/tests/MultiProjects/NuGetLoaded/README.md
@@ -1,9 +1,21 @@
 # NuGetLoaded Manual Test Projects
 
-Bu klasör Space NuGet paketlerinin publish edildikten sonra manuel olarak test edilmesi için haz?rlanm??t?r. Amaç repository içindeki kaynak projelere de?il yay?mlanan paketlere referans vermektir.
+Bu klasör Space NuGet paketlerinin publish edildikten sonra manuel olarak test edilmesi için haz?rlanm??t?r. Amaç repository içindeki kaynak projelere de?il yay?nlanan paketlere referans vermektir.
+
+## Önemli Breaking Change (v2.x)
+Önceki sürümlerde `Space.DependencyInjection` paketi otomatik olarak abstraction + source generator getiriyordu. Yeni sürümde:
+- `Space.Abstraction` paketi attribute'lar? ve Source Generator analyzer'?n? içerir.
+- `Space.DependencyInjection` yaln?zca DI uzant?lar? ve çal??ma zaman? implementasyonlar?n? içerir.
+
+Bu nedenle NuGet kullan?m?nda HER ?K? paketi referanslaman?z gerekir:
+```xml
+<PackageReference Include="Space.Abstraction" Version="2.0.0-preview" />
+<PackageReference Include="Space.DependencyInjection" Version="2.0.0-preview" />
+```
+Sadece attribute’lar ve derleme zaman? üretimi gerekiyorsa (örne?in ba?ka bir DI kabu?u) yaln?zca `Space.Abstraction` yeterlidir.
 
 ## Projeler
-- ApiHost (net8.0 Web API) - Root aggregator ( `<SpaceGenerateRootAggregator>true</SpaceGenerateRootAggregator>` )
+- ApiHost (net8.0 Web API) - Root aggregator (`<SpaceGenerateRootAggregator>true</SpaceGenerateRootAggregator>`)
 - LibAlpha (class library)
 - LibBeta (class library)
 
@@ -18,7 +30,7 @@ dotnet build -c Release /p:UseLocalSpaceProjects=false
 
 Ya da `ApiHost`, `LibAlpha`, `LibBeta` projelerinin `.csproj` dosyalar?ndaki `UseLocalSpaceProjects` özelli?ini false yap?n.
 
-NuGet paket versiyonlar?n? test etmek istedi?iniz gerçek versiyonlarla de?i?tirin (örn: `1.0.0-preview.3`).
+NuGet paket versiyonlar?n? test etmek istedi?iniz gerçek versiyonlarla de?i?tirin (örn: `2.0.0-preview.3`).
 
 ## Örnek Çal??t?rma
 ```
@@ -29,7 +41,7 @@ dotnet run --project tests/MultiProjects/NuGetLoaded/ApiHost/ApiHost.csproj
 ```
 GET http://localhost:5000/alpha/hello        -> AlphaHandled:hello
 GET http://localhost:5000/beta/5             -> Beta:5
-GET http://localhost:5000/multi/hi           -> AlphaHandled:hi (veya override senaryosu için ileride isimlendirilmi? handler ça?r?s? eklenebilir)
+GET http://localhost:5000/multi/hi           -> AlphaHandled:hi
 GET http://localhost:5000/notify/3           -> 3 adet notification publish eder
 ```
 
@@ -37,3 +49,4 @@ GET http://localhost:5000/notify/3           -> 3 adet notification publish eder
 - Paket testinde `Space.Modules.InMemoryCache` gibi ekstra modülleri de eklemek isterseniz ilgili PackageReference sat?r?n? aç?n.
 - Root projede `<SpaceGenerateRootAggregator>true</SpaceGenerateRootAggregator>` olmas? di?er class library projelerindeki handlerlar?n toplanmas? için gereklidir.
 - Handler / Pipeline say?s?n? artt?rarak gerçek senaryolar? manuel test edebilirsiniz.
+- Migration: Eski kullan?mda yaln?zca `Space.DependencyInjection` ekliydi; ?imdi ek olarak `Space.Abstraction` ?art.

--- a/tests/Space.Benchmarks/Space.Benchmarks.csproj
+++ b/tests/Space.Benchmarks/Space.Benchmarks.csproj
@@ -29,7 +29,6 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Space.Abstraction\Space.Abstraction.csproj" />
 		<ProjectReference Include="..\..\src\Space.DependencyInjection\Space.DependencyInjection.csproj" />
-		<ProjectReference Include="..\..\src\Space.SourceGenerator\Space.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Space.TestConsole/Space.TestConsole.csproj
+++ b/tests/Space.TestConsole/Space.TestConsole.csproj
@@ -10,7 +10,6 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Space.Abstraction\Space.Abstraction.csproj" />
 		<ProjectReference Include="..\..\src\Space.DependencyInjection\Space.DependencyInjection.csproj" />
-		<ProjectReference Include="..\..\src\Space.SourceGenerator\Space.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<!--<PropertyGroup>
@@ -22,12 +21,9 @@
 		<PackageReference Include="Space.Modules.InMemoryCache" Version="1.1.8" />
 	</ItemGroup>
 	
-	
 	<!--<ItemGroup>
 		<PackageReference Include="Space.Abstraction" Version="1.1.4" />
 		<PackageReference Include="Space.DependencyInjection" Version="1.1.4" />
-
-
 	</ItemGroup>-->
 
 </Project>


### PR DESCRIPTION
Breaking: Decoupled `Space.Abstraction` and `Space.DependencyInjection`. `Space.Abstraction` now includes the source generator analyzer, while `Space.DependencyInjection` is limited to DI extensions and runtime implementations. Updated documentation to guide migration.

Introduced `<SpaceGenerateRootAggregator>` for multi-project setups, enabling a single root aggregator for handler discovery. Updated examples and project files to reflect this change.

Refactored `ServiceCollectionExtensions` for modern C# features and improved code readability. Updated handler and pipeline examples to align with new API changes.

Enhanced documentation with detailed migration steps, known issues, and planned improvements. Removed outdated references to `Space.SourceGenerator` in project files.

Improved Turkish documentation and ensured consistency across all documentation files.
#79